### PR TITLE
Fix Typo in `abi.go`

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -29,7 +29,7 @@ import (
 )
 
 // The ABI holds information about a contract's context and available
-// invokable methods. It will allow you to type check function calls and
+// invocable methods. It will allow you to type check function calls and
 // packs data accordingly.
 type ABI struct {
 	Constructor Method


### PR DESCRIPTION
# Pull Request: Fix Typo in `abi.go`

## Description
This pull request corrects a minor typo in the **`abi.go`** file:
- Changed **"invocable methods"** to **"invocable methods"** to maintain consistency in the terminology.

## Changes
- **File:** `accounts/abi/abi.go`
  - Original: `// invocable methods. It will allow you to type check function calls and`
  - Updated: `// invocable methods. It will allow you to type check function calls and`

## Motivation and Context
This change corrects a small error in the documentation, ensuring it is clear and consistent for developers working with the ABI.

## Checklist
- [x] I have reviewed the changes for correctness.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new issues.

## Notes
- This change is purely a documentation update and does not affect the code's functionality.
- Thank you for reviewing this pull request!
